### PR TITLE
libretro: Add three more environment callback doxygen docs

### DIFF
--- a/libretro-common/include/libretro.h
+++ b/libretro-common/include/libretro.h
@@ -2403,32 +2403,36 @@ enum retro_mod
  */
 #define RETRO_ENVIRONMENT_GET_SAVESTATE_CONTEXT (72 | RETRO_ENVIRONMENT_EXPERIMENTAL)
 
-
+/**
+ * Before calling \c SET_HW_RENDER_CONTEXT_NEGOTIATION_INTERFACE, will query which interface is supported.
+ *
+ * Frontend looks at \c retro_hw_render_interface_type and returns the maximum supported
+ * context negotiation interface version. If the \c retro_hw_render_interface_type is not
+ * supported or recognized by the frontend, a version of 0 must be returned in
+ * \c retro_hw_render_interface's \c interface_version and \c true is returned by frontend.
+ *
+ * If this environment call returns true with a \c interface_version greater than 0,
+ * a core can always use a negotiation interface version larger than what the frontend returns,
+ * but only earlier versions of the interface will be used by the frontend.
+ *
+ * A frontend must not reject a negotiation interface version that is larger than what the
+ * frontend supports. Instead, the frontend will use the older entry points that it recognizes.
+ * If this is incompatible with a particular core's requirements, it can error out early.
+ *
+ * @note Regarding backwards compatibility, this environment call was introduced after Vulkan v1
+ * context negotiation. If this environment call is not supported by frontend, i.e. the environment
+ * call returns \c false , only Vulkan v1 context negotiation is supported (if Vulkan HW rendering
+ * is supported at all). If a core uses Vulkan negotiation interface with version > 1, negotiation
+ * may fail unexpectedly. All future updates to the context negotiation interface implies that
+ * frontend must support this environment call to query support.
+ *
+ * @param[out] data <tt>struct retro_hw_render_context_negotiation_interface *</tt>.
+ * @return \c true if the environment call is available.
+ * @see SET_HW_RENDER_CONTEXT_NEGOTIATION_INTERFACE
+ * @see retro_hw_render_interface_type
+ * @see retro_hw_render_context_negotiation_interface
+ */
 #define RETRO_ENVIRONMENT_GET_HW_RENDER_CONTEXT_NEGOTIATION_INTERFACE_SUPPORT (73 | RETRO_ENVIRONMENT_EXPERIMENTAL)
-                                            /* struct retro_hw_render_context_negotiation_interface * --
-                                             * Before calling SET_HW_RNEDER_CONTEXT_NEGOTIATION_INTERFACE, a core can query
-                                             * which version of the interface is supported.
-                                             *
-                                             * Frontend looks at interface_type and returns the maximum supported
-                                             * context negotiation interface version.
-                                             * If the interface_type is not supported or recognized by the frontend, a version of 0
-                                             * must be returned in interface_version and true is returned by frontend.
-                                             *
-                                             * If this environment call returns true with interface_version greater than 0,
-                                             * a core can always use a negotiation interface version larger than what the frontend returns, but only
-                                             * earlier versions of the interface will be used by the frontend.
-                                             * A frontend must not reject a negotiation interface version that is larger than
-                                             * what the frontend supports. Instead, the frontend will use the older entry points that it recognizes.
-                                             * If this is incompatible with a particular core's requirements, it can error out early.
-                                             *
-                                             * Backwards compatibility note:
-                                             * This environment call was introduced after Vulkan v1 context negotiation.
-                                             * If this environment call is not supported by frontend - i.e. the environment call returns false -
-                                             * only Vulkan v1 context negotiation is supported (if Vulkan HW rendering is supported at all).
-                                             * If a core uses Vulkan negotiation interface with version > 1, negotiation may fail unexpectedly.
-                                             * All future updates to the context negotiation interface implies that frontend must support
-                                             * this environment call to query support.
-                                             */
 
 /**
  * Asks the frontend whether JIT compilation can be used.
@@ -2452,24 +2456,26 @@ enum retro_mod
  */
 #define RETRO_ENVIRONMENT_GET_MICROPHONE_INTERFACE (75 | RETRO_ENVIRONMENT_EXPERIMENTAL)
 
-                                           /* Environment 76 was an obsolete version of RETRO_ENVIRONMENT_SET_NETPACKET_INTERFACE.
-                                            * It was not used by any known core at the time, and was removed from the API. */
+/* Environment 76 was an obsolete version of RETRO_ENVIRONMENT_SET_NETPACKET_INTERFACE.
+* It was not used by any known core at the time, and was removed from the API. */
 
+/**
+ * Returns the device's current power state as reported by the frontend.
+ *
+ * This is useful for emulating the battery level in handheld consoles,
+ * or for reducing power consumption when on battery power.
+ *
+ * @note This environment call describes the power state for the entire device,
+ * not for individual peripherals like controllers.
+ *
+ * @param[out] data <struct retro_device_power *>.
+ * Indicates whether the frontend can provide this information, even if the parameter
+ * is \c NULL. If the frontend does not support this functionality, then the provided
+ * argument will remain unchanged.
+ * @return \c true if the environment call is available.
+ * @see retro_device_power
+ */
 #define RETRO_ENVIRONMENT_GET_DEVICE_POWER (77 | RETRO_ENVIRONMENT_EXPERIMENTAL)
-                                           /* struct retro_device_power * --
-                                            * Returns the device's current power state as reported by the frontend.
-                                            * This is useful for emulating the battery level in handheld consoles,
-                                            * or for reducing power consumption when on battery power.
-                                            *
-                                            * The return value indicates whether the frontend can provide this information,
-                                            * even if the parameter is NULL.
-                                            *
-                                            * If the frontend does not support this functionality,
-                                            * then the provided argument will remain unchanged.
-                                            *
-                                            * Note that this environment call describes the power state for the entire device,
-                                            * not for individual peripherals like controllers.
-                                            */
 
 #define RETRO_ENVIRONMENT_SET_NETPACKET_INTERFACE 78
                                            /* const struct retro_netpacket_callback * --
@@ -2515,18 +2521,20 @@ enum retro_mod
  * not for individual peripherals like controllers.
 */
 #define RETRO_ENVIRONMENT_GET_DEVICE_POWER (77 | RETRO_ENVIRONMENT_EXPERIMENTAL)
+
+/**
+ * Returns the "playlist" directory of the frontend.
+ *
+ * This directory can be used to store core generated playlists, in case
+ * this internal functionality is available (e.g. internal core game detection
+ * engine).
+ *
+ * @param[out] data <tt>const char **</tt>.
+ * May be \c NULL. If so, no such directory is defined, and it's up to the
+ * implementation to find a suitable directory.
+ * @return \c true if the environment call is available.
+ */
 #define RETRO_ENVIRONMENT_GET_PLAYLIST_DIRECTORY 79
-                                           /* const char ** --
-                                            * Returns the "playlist" directory of the frontend.
-                                            * This directory can be used to store core generated playlists,
-                                            * in case this internal functionality is available (e.g. internal core
-                                            * game detection engine).
-                                            *
-                                            * The returned value can be NULL.
-                                            * If so, no such directory is defined,
-                                            * and it's up to the implementation to find a suitable directory.
-                                            */
-/* VFS functionality */
 
 /**@}*/
 


### PR DESCRIPTION
- `RETRO_ENVIRONMENT_GET_HW_RENDER_CONTEXT_NEGOTIATION_INTERFACE_SUPPORT`
- `RETRO_ENVIRONMENT_GET_DEVICE_POWER`
- `RETRO_ENVIRONMENT_GET_PLAYLIST_DIRECTORY`